### PR TITLE
Expose link and image title through the public API

### DIFF
--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -635,6 +635,7 @@ void LinkBase::applyLinkBase(const LinkBase &other,
     if (this != &other) {
         ItemWithOpts::applyItemWithOpts(other);
         setUrl(other.url());
+        setTitle(other.title());
         setText(other.text());
         setP(other.p()->clone(doc).staticCast<Paragraph>());
         setTextPos(other.textPos());
@@ -650,6 +651,16 @@ const QString &LinkBase::url() const
 void LinkBase::setUrl(const QString &u)
 {
     m_url = u;
+}
+
+const QString &LinkBase::title() const
+{
+    return m_title;
+}
+
+void LinkBase::setTitle(const QString &t)
+{
+    m_title = t;
 }
 
 const QString &LinkBase::text() const

--- a/src/doc.h
+++ b/src/doc.h
@@ -1365,6 +1365,10 @@ public:
      */
     void setUrl(const QString &u);
 
+    const QString &title() const;
+
+    void setTitle(const QString &t);
+
     /*!
      * Returns not parsed text of link's description.
      */
@@ -1423,6 +1427,7 @@ private:
      * URL.
      */
     QString m_url;
+    QString m_title;
     /*!
      * Not parsed content of link's description.
      */

--- a/src/doc.h
+++ b/src/doc.h
@@ -1365,8 +1365,16 @@ public:
      */
     void setUrl(const QString &u);
 
+    /*!
+     * Returns title of the link.
+     */
     const QString &title() const;
 
+    /*!
+     * Set title of the link.
+     *
+     * \a t New value.
+     */
     void setTitle(const QString &t);
 
     /*!

--- a/src/link_image_parser.cpp
+++ b/src/link_image_parser.cpp
@@ -289,6 +289,7 @@ void LinkImageParser::setImgAndP(const QPair<QSharedPointer<Paragraph>,
 }
 
 void LinkImageParser::makeLink(const QString &url,
+                               const QString &title,
                                QStringList &linksToParse,
                                const QString &path,
                                const QString &fileName,
@@ -308,6 +309,7 @@ void LinkImageParser::makeLink(const QString &url,
     auto link = QSharedPointer<Link>::create();
 
     link->setUrl(prepareUrl(url, linksToParse, path, fileName));
+    link->setTitle(title);
     link->setTextPos(textPos);
     link->setUrlPos(urlPos);
 
@@ -332,6 +334,7 @@ void LinkImageParser::makeLink(const QString &url,
 }
 
 void LinkImageParser::makeImage(const QString &url,
+                                const QString &title,
                                 QStringList &linksToParse,
                                 const QString &path,
                                 const QString &fileName,
@@ -351,6 +354,7 @@ void LinkImageParser::makeImage(const QString &url,
     auto img = QSharedPointer<Image>::create();
 
     img->setUrl(prepareUrl(url, linksToParse, path, fileName));
+    img->setTitle(title);
     img->setTextPos(textPos);
     img->setUrlPos(urlPos);
 
@@ -519,6 +523,7 @@ LinkImageParser::checkShortcutLinkImage(const State::Delim &startDelim,
         if (it != doc->labeledLinks().cend()) {
             if (startDelim.m_type == State::Delim::Link) {
                 makeLink(u,
+                         it.value()->title(),
                          linksToParse,
                          path,
                          fileName,
@@ -536,6 +541,7 @@ LinkImageParser::checkShortcutLinkImage(const State::Delim &startDelim,
                          endLinkLine);
             } else {
                 makeImage(it.value()->url(),
+                          it.value()->title(),
                           linksToParse,
                           path,
                           fileName,
@@ -745,6 +751,7 @@ bool LinkImageParser::checkInlineLinkImage(const State::Delim &startDelim,
 
                 if (startDelim.m_type == State::Delim::Link) {
                     makeLink(url,
+                             title.first,
                              linksToParse,
                              path,
                              fileName,
@@ -762,6 +769,7 @@ bool LinkImageParser::checkInlineLinkImage(const State::Delim &startDelim,
                              line.lineNumber());
                 } else {
                     makeImage(url,
+                              title.first,
                               linksToParse,
                               path,
                               fileName,
@@ -917,6 +925,10 @@ bool LinkImageParser::checkRefLinkImage(const State::Delim &startDelim,
 
                 if (it != doc->labeledLinks().cend()) {
                     img->setUrl(it.value()->url());
+                    img->setTitle(it.value()->title());
+                } else {
+                    img->setUrl(link->url());
+                    img->setTitle(link->title());
                 }
 
                 img->setStartColumn(startLabelPos);

--- a/src/link_image_parser.cpp
+++ b/src/link_image_parser.cpp
@@ -926,9 +926,6 @@ bool LinkImageParser::checkRefLinkImage(const State::Delim &startDelim,
                 if (it != doc->labeledLinks().cend()) {
                     img->setUrl(it.value()->url());
                     img->setTitle(it.value()->title());
-                } else {
-                    img->setUrl(link->url());
-                    img->setTitle(link->title());
                 }
 
                 img->setStartColumn(startLabelPos);

--- a/src/link_image_parser.h
+++ b/src/link_image_parser.h
@@ -150,6 +150,7 @@ private:
                            QStringList &linksToParse,
                            Parser &parser);
     void makeLink(const QString &url,
+                  const QString &title,
                   QStringList &linksToParse,
                   const QString &path,
                   const QString &fileName,
@@ -166,6 +167,7 @@ private:
                   qsizetype endLinkPos,
                   qsizetype endLinkLine);
     void makeImage(const QString &url,
+                   const QString &title,
                    QStringList &linksToParse,
                    const QString &path,
                    const QString &fileName,

--- a/src/paragraph_parser.cpp
+++ b/src/paragraph_parser.cpp
@@ -29,6 +29,7 @@ void ParagraphParser::clearRefLink()
 {
     m_reference.reset();
     m_refLinkLabel.clear();
+    m_refLinkTitle.clear();
     m_wasSpace = false;
     m_refLinkStage = RefLinkParserStage::S0;
     m_refLinkTextPos = {};
@@ -257,6 +258,11 @@ ParagraphParser::RefLinkState ParagraphParser::checkForReferenceLink(Line &curre
                                                  m_refLinkStartParenthesisCount,
                                                  m_refLinkTitleStartPos,
                                                  endStarted);
+                if (!title.isEmpty()) {
+                    if (!m_refLinkTitle.isEmpty())
+                        m_refLinkTitle.append(s_newLineChar);
+                    m_refLinkTitle.append(title);
+                }
 
                 if (m_refLinkTitlePos.startLine() == -1 && !m_refLinkTitleStartChar.isNull()) {
                     m_refLinkTitlePos.setStartColumn(titleStartPos);
@@ -341,6 +347,7 @@ qsizetype ParagraphParser::insertRefLink(QSharedPointer<Document> doc,
     m_startLine = pStartlineNumber;
 
     m_reference->setText(m_refLinkLabel);
+    m_reference->setTitle(m_refLinkTitle);
     m_reference->setTextPos(m_refLinkTextPos);
 
     if (m_refLinkTitlePos.endLine() != -1) {

--- a/src/paragraph_parser.cpp
+++ b/src/paragraph_parser.cpp
@@ -259,8 +259,9 @@ ParagraphParser::RefLinkState ParagraphParser::checkForReferenceLink(Line &curre
                                                  m_refLinkTitleStartPos,
                                                  endStarted);
                 if (!title.isEmpty()) {
-                    if (!m_refLinkTitle.isEmpty())
+                    if (!m_refLinkTitle.isEmpty()) {
                         m_refLinkTitle.append(s_newLineChar);
+                    }
                     m_refLinkTitle.append(title);
                 }
 

--- a/src/paragraph_parser.h
+++ b/src/paragraph_parser.h
@@ -243,6 +243,7 @@ private:
     qsizetype m_startLine = -1;
     RefLinkParserStage m_refLinkStage = RefLinkParserStage::S0;
     QString m_refLinkLabel;
+    QString m_refLinkTitle;
     WithPosition m_refLinkTextPos;
     WithPosition m_refLinkUrlPos;
     WithPosition m_refLinkTitlePos;

--- a/tests/auto/test_parser/main13.cpp
+++ b/tests/auto/test_parser/main13.cpp
@@ -1,0 +1,224 @@
+/*
+    SPDX-FileCopyrightText: 2026 Igor Mironchik <igor.mironchik@gmail.com>
+    SPDX-License-Identifier: MIT
+*/
+
+// doctest include.
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+// md4qt include.
+#include "parser.h"
+
+// Qt include.
+#include <QTextStream>
+
+/*
+[foo](/url "the title")
+*/
+TEST_CASE("link_title_inline_link_dquote")
+{
+    QString md = QStringLiteral("[foo](/url \"the title\")");
+    QTextStream stream(&md);
+    MD::Parser parser;
+    auto doc = parser.parse(stream, QString(), QString());
+
+    REQUIRE(doc->isEmpty() == false);
+    REQUIRE(doc->items().size() == 2);
+    REQUIRE(doc->items().at(1)->type() == MD::ItemType::Paragraph);
+    auto p = static_cast<MD::Paragraph *>(doc->items().at(1).get());
+    REQUIRE(p->items().size() == 1);
+    REQUIRE(p->items().at(0)->type() == MD::ItemType::Link);
+    auto l = static_cast<MD::Link *>(p->items().at(0).get());
+    REQUIRE(l->url() == QStringLiteral("/url"));
+    REQUIRE(l->title() == QStringLiteral("the title"));
+}
+
+/*
+[foo](/url 'the title')
+*/
+TEST_CASE("link_title_inline_link_squote")
+{
+    QString md = QStringLiteral("[foo](/url 'the title')");
+    QTextStream stream(&md);
+    MD::Parser parser;
+    auto doc = parser.parse(stream, QString(), QString());
+
+    REQUIRE(doc->isEmpty() == false);
+    REQUIRE(doc->items().size() == 2);
+    REQUIRE(doc->items().at(1)->type() == MD::ItemType::Paragraph);
+    auto p = static_cast<MD::Paragraph *>(doc->items().at(1).get());
+    REQUIRE(p->items().size() == 1);
+    REQUIRE(p->items().at(0)->type() == MD::ItemType::Link);
+    auto l = static_cast<MD::Link *>(p->items().at(0).get());
+    REQUIRE(l->url() == QStringLiteral("/url"));
+    REQUIRE(l->title() == QStringLiteral("the title"));
+}
+
+/*
+[foo](/url (the title))
+*/
+TEST_CASE("link_title_inline_link_parens")
+{
+    QString md = QStringLiteral("[foo](/url (the title))");
+    QTextStream stream(&md);
+    MD::Parser parser;
+    auto doc = parser.parse(stream, QString(), QString());
+
+    REQUIRE(doc->isEmpty() == false);
+    REQUIRE(doc->items().size() == 2);
+    REQUIRE(doc->items().at(1)->type() == MD::ItemType::Paragraph);
+    auto p = static_cast<MD::Paragraph *>(doc->items().at(1).get());
+    REQUIRE(p->items().size() == 1);
+    REQUIRE(p->items().at(0)->type() == MD::ItemType::Link);
+    auto l = static_cast<MD::Link *>(p->items().at(0).get());
+    REQUIRE(l->url() == QStringLiteral("/url"));
+    REQUIRE(l->title() == QStringLiteral("the title"));
+}
+
+/*
+[foo](/url)
+*/
+TEST_CASE("link_title_inline_link_none")
+{
+    QString md = QStringLiteral("[foo](/url)");
+    QTextStream stream(&md);
+    MD::Parser parser;
+    auto doc = parser.parse(stream, QString(), QString());
+
+    REQUIRE(doc->isEmpty() == false);
+    REQUIRE(doc->items().size() == 2);
+    REQUIRE(doc->items().at(1)->type() == MD::ItemType::Paragraph);
+    auto p = static_cast<MD::Paragraph *>(doc->items().at(1).get());
+    REQUIRE(p->items().size() == 1);
+    REQUIRE(p->items().at(0)->type() == MD::ItemType::Link);
+    auto l = static_cast<MD::Link *>(p->items().at(0).get());
+    REQUIRE(l->title().isEmpty());
+}
+
+/*
+![foo](/url "img title")
+*/
+TEST_CASE("link_title_inline_image")
+{
+    QString md = QStringLiteral("![foo](/url \"img title\")");
+    QTextStream stream(&md);
+    MD::Parser parser;
+    auto doc = parser.parse(stream, QString(), QString());
+
+    REQUIRE(doc->isEmpty() == false);
+    REQUIRE(doc->items().size() == 2);
+    REQUIRE(doc->items().at(1)->type() == MD::ItemType::Paragraph);
+    auto p = static_cast<MD::Paragraph *>(doc->items().at(1).get());
+    REQUIRE(p->items().size() == 1);
+    REQUIRE(p->items().at(0)->type() == MD::ItemType::Image);
+    auto img = static_cast<MD::Image *>(p->items().at(0).get());
+    REQUIRE(img->url() == QStringLiteral("/url"));
+    REQUIRE(img->title() == QStringLiteral("img title"));
+}
+
+/*
+[foo]
+
+[foo]: /url "my title"
+*/
+TEST_CASE("link_title_shortcut_link")
+{
+    QString md = QStringLiteral("[foo]\n\n[foo]: /url \"my title\"");
+    QTextStream stream(&md);
+    MD::Parser parser;
+    auto doc = parser.parse(stream, QString(), QStringLiteral("test.md"));
+
+    REQUIRE(doc->isEmpty() == false);
+    REQUIRE(doc->items().size() == 2);
+    REQUIRE(doc->items().at(1)->type() == MD::ItemType::Paragraph);
+    auto p = static_cast<MD::Paragraph *>(doc->items().at(1).get());
+    REQUIRE(p->items().size() == 1);
+    REQUIRE(p->items().at(0)->type() == MD::ItemType::Link);
+    auto l = static_cast<MD::Link *>(p->items().at(0).get());
+    REQUIRE(l->title() == QStringLiteral("my title"));
+}
+
+/*
+![foo]
+
+[foo]: /url "my title"
+*/
+TEST_CASE("link_title_shortcut_image")
+{
+    QString md = QStringLiteral("![foo]\n\n[foo]: /url \"my title\"");
+    QTextStream stream(&md);
+    MD::Parser parser;
+    auto doc = parser.parse(stream, QString(), QStringLiteral("test.md"));
+
+    REQUIRE(doc->isEmpty() == false);
+    REQUIRE(doc->items().size() == 2);
+    REQUIRE(doc->items().at(1)->type() == MD::ItemType::Paragraph);
+    auto p = static_cast<MD::Paragraph *>(doc->items().at(1).get());
+    REQUIRE(p->items().size() == 1);
+    REQUIRE(p->items().at(0)->type() == MD::ItemType::Image);
+    auto img = static_cast<MD::Image *>(p->items().at(0).get());
+    REQUIRE(img->url() == QStringLiteral("/url"));
+    REQUIRE(img->title() == QStringLiteral("my title"));
+}
+
+/*
+[text][foo]
+
+[foo]: /url "my title"
+*/
+TEST_CASE("link_title_full_ref_link")
+{
+    QString md = QStringLiteral("[text][foo]\n\n[foo]: /url \"my title\"");
+    QTextStream stream(&md);
+    MD::Parser parser;
+    auto doc = parser.parse(stream, QString(), QStringLiteral("test.md"));
+
+    REQUIRE(doc->isEmpty() == false);
+    REQUIRE(doc->items().size() == 2);
+    REQUIRE(doc->items().at(1)->type() == MD::ItemType::Paragraph);
+    auto p = static_cast<MD::Paragraph *>(doc->items().at(1).get());
+    REQUIRE(p->items().size() == 1);
+    REQUIRE(p->items().at(0)->type() == MD::ItemType::Link);
+    auto l = static_cast<MD::Link *>(p->items().at(0).get());
+    REQUIRE(l->title() == QStringLiteral("my title"));
+}
+
+/*
+![alt][foo]
+
+[foo]: /url "my title"
+*/
+TEST_CASE("link_title_full_ref_image")
+{
+    QString md = QStringLiteral("![alt][foo]\n\n[foo]: /url \"my title\"");
+    QTextStream stream(&md);
+    MD::Parser parser;
+    auto doc = parser.parse(stream, QString(), QStringLiteral("test.md"));
+
+    REQUIRE(doc->isEmpty() == false);
+    REQUIRE(doc->items().size() == 2);
+    REQUIRE(doc->items().at(1)->type() == MD::ItemType::Paragraph);
+    auto p = static_cast<MD::Paragraph *>(doc->items().at(1).get());
+    REQUIRE(p->items().size() == 1);
+    REQUIRE(p->items().at(0)->type() == MD::ItemType::Image);
+    auto img = static_cast<MD::Image *>(p->items().at(0).get());
+    REQUIRE(img->url() == QStringLiteral("/url"));
+    REQUIRE(img->title() == QStringLiteral("my title"));
+}
+
+/*
+[foo]: /url "definition title"
+*/
+TEST_CASE("link_title_labeled_definition")
+{
+    QString md = QStringLiteral("[foo]: /url \"definition title\"");
+    QTextStream stream(&md);
+    MD::Parser parser;
+    auto doc = parser.parse(stream, QString(), QStringLiteral("test.md"));
+
+    REQUIRE(doc->labeledLinks().size() == 1);
+    const auto it = doc->labeledLinks().cbegin();
+    REQUIRE(it.value()->url() == QStringLiteral("/url"));
+    REQUIRE(it.value()->title() == QStringLiteral("definition title"));
+}


### PR DESCRIPTION
Previously, md4qt parsed the optional title from inline links ([text](url title)) and reference definitions ([label]: url title) but discarded the text entirely -- only positional metadata was retained.

This change stores the title string on LinkBase (shared by Link and Image) via a new title()/setTitle() pair, and threads it through makeLink(), makeImage(), and the reference-link paragraph parser so that callers can read the title without a separate lookup.

No behavioural change for callers that do not use the new accessor.

This is a supported feature of CommonMark.